### PR TITLE
Handle latest pytest output

### DIFF
--- a/tests/test_flakefinder.py
+++ b/tests/test_flakefinder.py
@@ -66,7 +66,7 @@ def test_unittest_repeats(testdir, flags, runs):
     # Check output.
     result.stdout.fnmatch_lines(
         # NB: unitest TestCases don't increment the collected items.
-        ['collecting ... collected 1 item'] +
+        ['collecting ... collected 1 item*'] +
         ['*::TestAwesome::test PASSED*' for _ in range(runs)]
     )
     assert result.ret == 0

--- a/tests/test_flakefinder.py
+++ b/tests/test_flakefinder.py
@@ -162,7 +162,7 @@ def test_flake_max_minutes(testdir, minutes):
         ['*::test?%d? PASSED*' % i for i in range(min(runs, passing_runs))] +
         ['*::test?%d? SKIPPED*' % i for i in range(passing_runs, runs)] +
         # Test for the test, make sure the time isn't modified when coming out.
-        ['* 10 passed, 40 skipped, * in ?.?? seconds *']
+        ['* 10 passed, 40 skipped* in ?.?? seconds *']
     )
     assert result.ret == 0
 

--- a/tests/test_flakefinder.py
+++ b/tests/test_flakefinder.py
@@ -35,9 +35,10 @@ def test_repeat_success(testdir, flags, runs):
 
     # Check output.
     result.stdout.fnmatch_lines(
-        ['collecting ... collected %d items' % runs] +
+        # Wildcard at end because latest pytest pluralizes 'item'
+        ['collecting ... collected %d item*' % runs] +
         # fnmatch doesn't like `[` characters so I use `?`.
-        ['*::test?%d? PASSED' % i for i in range(runs)]
+        ['*::test?%d? PASSED*' % i for i in range(runs)]
     )
     assert result.ret == 0
 
@@ -65,8 +66,8 @@ def test_unittest_repeats(testdir, flags, runs):
     # Check output.
     result.stdout.fnmatch_lines(
         # NB: unitest TestCases don't increment the collected items.
-        ['collecting ... collected 1 items'] +
-        ['*::TestAwesome::test PASSED' for _ in range(runs)]
+        ['collecting ... collected 1 item'] +
+        ['*::TestAwesome::test PASSED*' for _ in range(runs)]
     )
     assert result.ret == 0
 
@@ -92,9 +93,9 @@ def test_flaky_test(testdir, flags, runs):
     # Check output.
     result.stdout.fnmatch_lines(
         ['collecting ... collected %d items' % runs] +
-        ['*::test?%d? PASSED' % i for i in range(min(runs, 20))] +
-        ['*::test?%d? FAILED' % i for i in range(20, min(runs, 21))] +
-        ['*::test?%d? PASSED' % i for i in range(21, runs)]
+        ['*::test?%d? PASSED*' % i for i in range(min(runs, 20))] +
+        ['*::test?%d? FAILED*' % i for i in range(20, min(runs, 21))] +
+        ['*::test?%d? PASSED*' % i for i in range(21, runs)]
     )
     assert result.ret == 0 if runs < 20 else 1
 
@@ -115,7 +116,7 @@ def test_parametrized_tests(testdir):
     # Check output.
     result.stdout.fnmatch_lines(
         ['collecting ... collected 150 items'] +
-        ['*::test?%d-%d? PASSED' % (i, x)
+        ['*::test?%d-%d? PASSED*' % (i, x)
          for i in range(pytest_flakefinder.DEFAULT_FLAKE_RUNS)
          for x in [1, 5, 10]]
     )
@@ -158,10 +159,10 @@ def test_flake_max_minutes(testdir, minutes):
     result.stdout.fnmatch_lines(
         # fnmatch doesn't like `[` characters so I use `?`.
         ['collecting ... collected %d items' % runs] +
-        ['*::test?%d? PASSED' % i for i in range(min(runs, passing_runs))] +
-        ['*::test?%d? SKIPPED' % i for i in range(passing_runs, runs)] +
+        ['*::test?%d? PASSED*' % i for i in range(min(runs, passing_runs))] +
+        ['*::test?%d? SKIPPED*' % i for i in range(passing_runs, runs)] +
         # Test for the test, make sure the time isn't modified when coming out.
-        ['* 10 passed, 40 skipped in ?.?? seconds *']
+        ['* 10 passed, 40 skipped, * in ?.?? seconds *']
     )
     assert result.ret == 0
 
@@ -191,7 +192,7 @@ def test_flake_derived_classes(testdir):
         # NB: unitest TestCases don't increment the collected items.
         ['collecting ... collected 2 items'] +
         # The bug was that TestAwesome wouldn't run multiple times.
-        ['*::TestAwesome::runTest PASSED'
+        ['*::TestAwesome::runTest PASSED*'
          for _ in range(pytest_flakefinder.DEFAULT_FLAKE_RUNS)]
     )
     assert result.ret == 0

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,6 @@
 [tox]
 envlist = py27,py34
 [testenv]
-deps=pytest       # install pytest in the venvs
+; install pytest in the venvs
+deps=pytest
 commands=py.test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 # For more information about tox, see https://tox.readthedocs.org/en/latest/
 [tox]
-envlist = py27,py34
+envlist = py{27,34,36}-pytest{325,330,latest}
 [testenv]
-; install pytest in the venvs
-deps=pytest
+deps=
+    pytest325: pytest==3.2.5
+    pytest330: pytest==3.3.0
+    pytestlatest: pytest
 commands=py.test


### PR DESCRIPTION
The latest versions of `pytest` (3.3.0+) have some changes to the output
that break the flakefinder tests:

- `collected X items` is now properly pluralized
- By default, pytest output now adds the test progress percent to the
  end of each line.

Also a tweak to a comment in `tox.ini` that was breaking for `tox` on
Python 3.6.

Also, 3.3.0+ will now print out warning logs indicating
`metafunc.addcall` is deprecated and will be removed in 4.0+. This
breaks one of the tests that check the summary output. So patch that for
now. I have another fix to handle the deprecation coming up. Just needed
working tests first!