### PR TITLE
Handle addcall deprecation

### DIFF
--- a/pytest_flakefinder.py
+++ b/pytest_flakefinder.py
@@ -52,9 +52,9 @@ class FlakeFinderPlugin(object):
         # This is safer because otherwise test with fixtures might not be setup correctly.
         # Parameterization requires the test function to accept the permutation as
         # either an argument or depend on it as a fixture. Use fixture so the test
-        # function signature is not changed. Suffix with timestamp to reduce odds of
-        # collision with other fixture names.
-        fixture_name = 'flakefinder-{}'.format(time.time())
+        # function signature is not changed. Prefix with underscores and suffix with
+        # function name to reduce odds of collision with other fixture names.
+        fixture_name = '__flakefinder_{}'.format(metafunc.function.__name__)
         metafunc.fixturenames.append(fixture_name)
         metafunc.parametrize(
             argnames=fixture_name,

--- a/pytest_flakefinder.py
+++ b/pytest_flakefinder.py
@@ -50,8 +50,16 @@ class FlakeFinderPlugin(object):
     def pytest_generate_tests(self, metafunc):
         """For all true pytest tests use metafunc to add all the duplicates."""
         # This is safer because otherwise test with fixtures might not be setup correctly.
-        for _ in range(self.flake_runs):
-            metafunc.addcall()
+        # Parameterization requires the test function to accept the permutation as
+        # either an argument or depend on it as a fixture. Use fixture so the test
+        # function signature is not changed. Suffix with timestamp to reduce odds of
+        # collision with other fixture names.
+        fixture_name = 'flakefinder-{}'.format(time.time())
+        metafunc.fixturenames.append(fixture_name)
+        metafunc.parametrize(
+            argnames=fixture_name,
+            argvalues=list(range(self.flake_runs)),
+        )
         metafunc.function._pytest_duplicated = True
 
     @pytest.mark.tryfirst

--- a/tests/test_flakefinder.py
+++ b/tests/test_flakefinder.py
@@ -197,3 +197,33 @@ def test_flake_derived_classes(testdir):
          for _ in range(pytest_flakefinder.DEFAULT_FLAKE_RUNS)]
     )
     assert result.ret == 0
+
+def test_fixture_parametrization_with_similar_test_names(testdir):
+    """
+    Ensure tests with the same name in diff namespaces do not cause overloading of
+    flake runs.
+    """
+    testdir.makepyfile("""
+    class TestA(object):
+        def test_something(self):
+            pass
+    
+    class TestB(object):
+        def test_something(self):
+            pass
+    
+    def test_something():
+        pass
+    """)
+
+    # Run pytest.
+    flags = ['--flake-finder', '-v']
+    result = testdir.runpytest(*flags)
+
+    # Check output.
+    num_runs = pytest_flakefinder.DEFAULT_FLAKE_RUNS
+    result.stdout.fnmatch_lines(
+        ['collecting ... collected 150 items'] +
+        ['*::test_something?%d? PASSED*' % i for i in range(num_runs)]
+    )
+    assert result.ret == 0

--- a/tests/test_flakefinder.py
+++ b/tests/test_flakefinder.py
@@ -35,7 +35,7 @@ def test_repeat_success(testdir, flags, runs):
 
     # Check output.
     result.stdout.fnmatch_lines(
-        # Wildcard at end because latest pytest pluralizes 'item'
+        # Wildcard at end because different Python+pytest combos pluralize 'item'
         ['collecting ... collected %d item*' % runs] +
         # fnmatch doesn't like `[` characters so I use `?`.
         ['*::test?%d? PASSED*' % i for i in range(runs)]
@@ -66,6 +66,7 @@ def test_unittest_repeats(testdir, flags, runs):
     # Check output.
     result.stdout.fnmatch_lines(
         # NB: unitest TestCases don't increment the collected items.
+        # Wildcard at end because different Python+pytest combos pluralize 'item'
         ['collecting ... collected 1 item*'] +
         ['*::TestAwesome::test PASSED*' for _ in range(runs)]
     )
@@ -162,7 +163,7 @@ def test_flake_max_minutes(testdir, minutes):
         ['*::test?%d? PASSED*' % i for i in range(min(runs, passing_runs))] +
         ['*::test?%d? SKIPPED*' % i for i in range(passing_runs, runs)] +
         # Test for the test, make sure the time isn't modified when coming out.
-        ['* 10 passed, 40 skipped* in ?.?? seconds *']
+        ['* 10 passed, 40 skipped in ?.?? seconds *']
     )
     assert result.ret == 0
 


### PR DESCRIPTION
Now that #4 is merged, I can do: Handle `addcall` deprecation!
 
In `ptytest` v3.3.0+, `metafunc.addcall` is deprecated and is slated
to be removed in v4.0. [See changelog][1]

The recommendation is to use `metafunc.parametrize`. The twist is that
parametrization requires the value to either be taken as an argument by
the function or as a fixture. So a dynamic fixture is created and added
to each test function to avoid needing to change the test function
signatures.

[1]: https://docs.pytest.org/en/latest/changelog.html#id38