### PR TITLE
Fix unittest cases on flakefinder via hax

### DIFF
--- a/pytest_flakefinder.py
+++ b/pytest_flakefinder.py
@@ -73,8 +73,13 @@ class FlakeFinderPlugin(object):
         # Also we want to @tryfirst so that we go before randomizing the list.
         for item in list(items):
             if not getattr(item.function, '_pytest_duplicated', None):
-                for _ in range(self.flake_runs - 1):
-                    items.append(copy.copy(item))
+                for i in range(self.flake_runs - 1):
+                    cpy = copy.copy(item)
+                    # HAX
+                    # Ensure initialization for the copied request works for _pytest.TestCaseFunction
+                    # without this, funcargs ends up being None
+                    cpy._initrequest()
+                    items.append(cpy)
 
     def pytest_runtest_call(self, item):
         """Skip tests if we've run out of time."""

--- a/tests/test_flakefinder.py
+++ b/tests/test_flakefinder.py
@@ -42,7 +42,6 @@ def test_repeat_success(testdir, flags, runs):
     )
     assert result.ret == 0
 
-@pytest.mark.skipif(int(pytest.__version__.split('.')[0]) > 3, reason="unittest functionality stopped working at v4")
 @pytest.mark.parametrize("flags, runs", [
     ([], pytest_flakefinder.DEFAULT_FLAKE_RUNS),
     (["--flake-runs=1"], 1),
@@ -168,7 +167,6 @@ def test_flake_max_minutes(testdir, minutes):
     )
     assert result.ret == 0
 
-@pytest.mark.skipif(int(pytest.__version__.split('.')[0]) > 3, reason="unittest functionality stopped working at v4")
 def test_flake_derived_classes(testdir):
     """Tests that if two tests share the same function they still get duped properly."""
 


### PR DESCRIPTION
You're not going to like this @euresti - but it works!

The copied requests were failing on the latest pytest version because the fixture _request is wrapping the original object. A deep copy would have solved this, but deepcopy doesn't work for item. Instead, this reinitializes cpy._request allowing funcargs to be set correctly!
It works!