### PR TITLE
Change command from py.test to pytest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,19 +38,19 @@ Flake Finding
 
 Enable plugin for tests::
 
-    py.test --flake-finder
+    pytest --flake-finder
 
 This will run every test the default, 50, times.  Every test is run independently and you can even use xdist to send tests to multiple processes.
 
 To configure the number of runs::
 
-    py.test --flake-finder --flake-runs=runs
+    pytest --flake-finder --flake-runs=runs
 
 To find flakes in one test or a couple of tests you can use pytest's built in test selectiong.
 
 Finding flakes in one test::
 
-    py.test -k test_maybe_flaky --flake-finder
+    pytest -k test_maybe_flaky --flake-finder
 
 When used with xdist the flake finder can expose many timing related flakes.
 
@@ -61,7 +61,7 @@ When using flake-finder as part of a CI run it might be useful to limit the amou
 
 Running with timeout::
 
-    py.test --flake-finder --flake-max-minutes=minutes
+    pytest --flake-finder --flake-max-minutes=minutes
 
 Tests started after the timeout will be skipped.
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ deps=
 
     # Pin attrs to an older version when testing older pytest for compatibility
     pytest3{0,1,25,30}: attrs==17.4.0
-commands=py.test
+commands=pytest


### PR DESCRIPTION
Pytest has renamed it's command since version 2.0.
I assume that it's better to follow their naming convention.

See:
* https://docs.pytest.org/en/documentation-restructure/how-to/naming20.html
* https://docs.pytest.org/en/latest/faq.html#why-can-i-use-both-pytest-and-py-test-commands
* https://meta.stackoverflow.com/questions/366905/rename-py-test-to-pytest