### PR TITLE
Fix deprecation warning

### DIFF
--- a/pytest_flakefinder.py
+++ b/pytest_flakefinder.py
@@ -23,14 +23,15 @@ def pytest_addoption(parser):
                     default=DEFAULT_FLAKE_RUNS,
                     type=int,
                     metavar="runs",
-                    help="number of times to repeat the tests. (default: %default)")
+                    help="number of times to repeat the tests. (default: %(default)s)")
     group.addoption("--flake-max-minutes",
                     action="store",
                     dest="flake_max_minutes",
                     default=DEFAULT_FLAKE_MINUTES,
                     type=int,
                     metavar="minutes",
-                    help="Don't run for longer than this parameter. (default: %default)")
+                    help="Don't run for longer than this parameter. (default: %(default)s)")
+
 
 def pytest_configure(config):
     """Register the plugin if needed."""

--- a/pytest_flakefinder.py
+++ b/pytest_flakefinder.py
@@ -74,7 +74,7 @@ class FlakeFinderPlugin(object):
         # Also we want to @tryfirst so that we go before randomizing the list.
         for item in list(items):
             if not getattr(item.function, '_pytest_duplicated', None):
-                for i in range(self.flake_runs - 1):
+                for _ in range(self.flake_runs - 1):
                     cpy = copy.copy(item)
                     # HAX
                     # Ensure initialization for the copied request works for _pytest.TestCaseFunction

--- a/pytest_flakefinder.py
+++ b/pytest_flakefinder.py
@@ -1,8 +1,9 @@
 """Run a test multiple times to see if it's flaky."""
 
 import copy
-import pytest
 import time
+
+import pytest
 
 DEFAULT_FLAKE_RUNS = 50
 DEFAULT_FLAKE_MINUTES = 0
@@ -10,32 +11,38 @@ DEFAULT_FLAKE_MINUTES = 0
 
 def pytest_addoption(parser):
     """Add options for flakefinder plugin."""
-    group = parser.getgroup('flakefinder')
+    group = parser.getgroup("flakefinder")
 
-    group.addoption("--flake-finder",
-                    action='store_true',
-                    dest="flake_finder_enable",
-                    default=False,
-                    help="create multiple copies of all the selected tests.")
-    group.addoption("--flake-runs",
-                    action='store',
-                    dest="flake_runs",
-                    default=DEFAULT_FLAKE_RUNS,
-                    type=int,
-                    metavar="runs",
-                    help="number of times to repeat the tests. (default: %(default)s)")
-    group.addoption("--flake-max-minutes",
-                    action="store",
-                    dest="flake_max_minutes",
-                    default=DEFAULT_FLAKE_MINUTES,
-                    type=int,
-                    metavar="minutes",
-                    help="Don't run for longer than this parameter. (default: %(default)s)")
+    group.addoption(
+        "--flake-finder",
+        action="store_true",
+        dest="flake_finder_enable",
+        default=False,
+        help="create multiple copies of all the selected tests.",
+    )
+    group.addoption(
+        "--flake-runs",
+        action="store",
+        dest="flake_runs",
+        default=DEFAULT_FLAKE_RUNS,
+        type=int,
+        metavar="runs",
+        help="number of times to repeat the tests. (default: %(default)s)",
+    )
+    group.addoption(
+        "--flake-max-minutes",
+        action="store",
+        dest="flake_max_minutes",
+        default=DEFAULT_FLAKE_MINUTES,
+        type=int,
+        metavar="minutes",
+        help="Don't run for longer than this parameter. (default: %(default)s)",
+    )
 
 
 def pytest_configure(config):
     """Register the plugin if needed."""
-    if config.getoption('flake_finder_enable'):
+    if config.getoption("flake_finder_enable"):
         config.pluginmanager.register(FlakeFinderPlugin(config))
 
 
@@ -43,8 +50,8 @@ class FlakeFinderPlugin(object):
     """This is a pytest plugin that multiplies all selected tests by `flake_runs`."""
 
     def __init__(self, config):
-        self.flake_runs = config.getoption('flake_runs')
-        self.expires = config.getoption('flake_max_minutes')
+        self.flake_runs = config.getoption("flake_runs")
+        self.expires = config.getoption("flake_max_minutes")
         if self.expires:
             self.expires = time.time() + self.expires * 60
 
@@ -56,7 +63,7 @@ class FlakeFinderPlugin(object):
         # either an argument or depend on it as a fixture. Use fixture so the test
         # function signature is not changed. Prefix with underscores and suffix with
         # function name to reduce odds of collision with other fixture names.
-        fixture_name = '__flakefinder_{}'.format(metafunc.function.__name__)
+        fixture_name = "__flakefinder_{}".format(metafunc.function.__name__)
         metafunc.fixturenames.append(fixture_name)
         metafunc.parametrize(
             argnames=fixture_name,
@@ -73,7 +80,7 @@ class FlakeFinderPlugin(object):
         #
         # Also we want to @tryfirst so that we go before randomizing the list.
         for item in list(items):
-            if not getattr(item.function, '_pytest_duplicated', None):
+            if not getattr(item.function, "_pytest_duplicated", None):
                 for _ in range(self.flake_runs - 1):
                     cpy = copy.copy(item)
                     # HAX


### PR DESCRIPTION
I see deprecationwarnings when I call pytest.main in a test. The problem can be reproduced even in this repo with:
```python
def test_depr_warning():
    pytest.main(['--collect-only', '-q', './'])
```

The warnings:
```
lib/python3.8/site-packages/pytest_flakefinder.py:20: PytestRemovedIn8Warning: pytest now uses argparse. "%default" should be changed to "%(default)s"
    group.addoption("--flake-runs",

lib/python3.8/site-packages/pytest_flakefinder.py:27: PytestRemovedIn8Warning: pytest now uses argparse. "%default" should be changed to "%(default)s"
    group.addoption("--flake-max-minutes",
```


pytest raises this DeprecationWarning here:
https://github.com/pytest-dev/pytest/blob/176d2d7b4e21b19fb08afdb3f9db61495eff5647/src/_pytest/config/argparsing.py#L234
The warning implementation is clear that it won't be supported in the next major release: https://github.com/pytest-dev/pytest/blob/176d2d7b4e21b19fb08afdb3f9db61495eff5647/src/_pytest/deprecated.py#L50

I suggest to solve this by using the format suggested by the warning, I see no reason not to. Implemented in this PR. Please release a pypi package as well. Thank you!

